### PR TITLE
Fix CMSIS-NN Include path

### DIFF
--- a/projects/vision_board_openmv/board/ports/CMSIS-NN/SConscript
+++ b/projects/vision_board_openmv/board/ports/CMSIS-NN/SConscript
@@ -17,8 +17,8 @@ src += Glob('Source/SoftmaxFunctions/*.c')
 src += Glob('Source/SVDFunctions/*.c')
 
 path    = [cwd + '/']
-path    += [cwd + '/include']
-path    += [cwd + '/include/Internal']
+path    += [cwd + '/Include']
+path    += [cwd + '/Include/Internal']
 
 CPPDEFINES = ['CMSIS_NN']
 


### PR DESCRIPTION
The CMSIS-NN library's include path was incorrect. 
It was using 'include' instead of 'Include'.
This commit resolves the issue by updating the include path to use the correct 'Include' folder name.