### PR TITLE
[driver]Add ra8 sci-uart support.

### DIFF
--- a/libraries/HAL_Drivers/drv_sci.h
+++ b/libraries/HAL_Drivers/drv_sci.h
@@ -23,7 +23,9 @@
 extern "C" {
 #endif
 
-rt_err_t drv_sci_spi_device_attach(const char *bus_name, const char *device_name, rt_base_t cs_pin);
+#ifdef BSP_USING_SCIn_SPI
+rt_err_t rt_hw_sci_spi_device_attach(const char *bus_name, const char *device_name, rt_base_t cs_pin);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
添加ra8的sci-uart支持，之前的api太老了，编译会报错。

* 以sci0配置为uart为例：

![image](https://github.com/user-attachments/assets/8d445354-6826-4ce1-b0ba-1d0629c00676)

![image](https://github.com/user-attachments/assets/713000af-0539-42e0-8c7a-08f54201c2b6)

